### PR TITLE
Laravel 5.3 Compatibility

### DIFF
--- a/src/Postmark/Adapters/LaravelMailProvider.php
+++ b/src/Postmark/Adapters/LaravelMailProvider.php
@@ -1,92 +1,90 @@
-<?php
-namespace Postmark\Adapters;
+<?php namespace Postmark\Adapters;
 
 use Illuminate\Mail\Mailer;
 use Illuminate\Support\ServiceProvider;
 use Swift_Mailer;
 
-class LaravelMailProvider extends ServiceProvider
-{
-    /**
-     * Indicates if loading of the provider is deferred.
-     *
-     * @var bool
-     */
-    protected $defer = true;
+class LaravelMailProvider extends ServiceProvider {
+	/**
+	 * Indicates if loading of the provider is deferred.
+	 *
+	 * @var bool
+	 */
+	protected $defer = true;
 
-    /**
-     * Register the service provider.
-     *
-     * @return void
-     */
-    public function register()
-    {
-            $this->registerSwiftMailer();
+	/**
+	 * Register the service provider.
+	 *
+	 * @return void
+	 */
+	public function register()
+	{
+		$this->registerSwiftMailer();
 
-            $this->app->singleton('mailer', function ($app) {
-            // Once we have create the mailer instance, we will set a container instance
-            // on the mailer. This allows us to resolve mailer classes via containers
-            // for maximum testability on said classes instead of passing Closures.
-            $mailer = new Mailer(
-                $app['view'], $app['swift.mailer'], $app['events']
-            );
+		$this->app->singleton('mailer', function ($app) {
+			// Once we have create the mailer instance, we will set a container instance
+			// on the mailer. This allows us to resolve mailer classes via containers
+			// for maximum testability on said classes instead of passing Closures.
+			$mailer = new Mailer(
+				$app['view'], $app['swift.mailer'], $app['events']
+			);
 
-            $this->setMailerDependencies($mailer, $app);
+			$this->setMailerDependencies($mailer, $app);
 
-            // If a "from" address is set, we will set it on the mailer so that all mail
-            // messages sent by the applications will utilize the same "from" address
-            // on each one, which makes the developer's life a lot more convenient.
-            $from = $app['config']['mail.from'];
+			// If a "from" address is set, we will set it on the mailer so that all mail
+			// messages sent by the applications will utilize the same "from" address
+			// on each one, which makes the developer's life a lot more convenient.
+			$from = $app['config']['mail.from'];
 
-            if (is_array($from) && isset($from['address'])) {
-                $mailer->alwaysFrom($from['address'], $from['name']);
-            }
+			if (is_array($from) && isset($from['address'])) {
+				$mailer->alwaysFrom($from['address'], $from['name']);
+			}
 
-            $to = $app['config']['mail.to'];
+			$to = $app['config']['mail.to'];
 
-            if (is_array($to) && isset($to['address'])) {
-                $mailer->alwaysTo($to['address'], $to['name']);
-            }
+			if (is_array($to) && isset($to['address'])) {
+				$mailer->alwaysTo($to['address'], $to['name']);
+			}
 
-            return $mailer;
-        });
-    }
+			return $mailer;
+		});
+	}
 
-    /**
-     * Set a few dependencies on the mailer instance.
-     *
-     * @param  \Illuminate\Mail\Mailer  $mailer
-     * @param  \Illuminate\Foundation\Application  $app
-     * @return void
-     */
-    protected function setMailerDependencies($mailer, $app)
-    {
-        $mailer->setContainer($app);
+	/**
+	 * Set a few dependencies on the mailer instance.
+	 *
+	 * @param  \Illuminate\Mail\Mailer  $mailer
+	 * @param  \Illuminate\Foundation\Application  $app
+	 * @return void
+	 */
+	protected function setMailerDependencies($mailer, $app)
+	{
+		$mailer->setContainer($app);
 
-        if ($app->bound('queue')) {
-            $mailer->setQueue($app['queue']);
-        }
-    }
+		if ($app->bound('queue')) {
+			$mailer->setQueue($app['queue']);
+		}
+	}
 
-    /**
-     * Register the Swift Mailer instance.
-     *
-     * @return void
-     */
-    public function registerSwiftMailer() {
-        $this->app['swift.mailer'] = $this->app->share(function ($app) {
-            $token = $this->app['config']->get('services.postmark');
-            return new Swift_Mailer(new \Postmark\Transport($token));
-        });
-    }
+	/**
+	 * Register the Swift Mailer instance.
+	 *
+	 * @return void
+	 */
+	public function registerSwiftMailer() {
+		$this->app['swift.mailer'] = $this->app->share(function ($app) {
+			$token = $this->app['config']->get('services.postmark');
+			return new Swift_Mailer(new \Postmark\Transport($token));
+		});
+	}
 
-    /**
-     * Get the services provided by the provider.
-     *
-     * @return array
-     */
+	/**
+	 * Get the services provided by the provider.
+	 *
+	 * @return array
+	 */
     public function provides() {
-        return ['mailer', 'swift.mailer'];
-    }
+		return ['mailer', 'swift.mailer'];
+	}
 
 }

--- a/src/Postmark/Adapters/LaravelMailProvider.php
+++ b/src/Postmark/Adapters/LaravelMailProvider.php
@@ -7,40 +7,40 @@ use Swift_Mailer;
 
 class LaravelMailProvider extends ServiceProvider
 {
-	/**
+    /**
      * Indicates if loading of the provider is deferred.
      *
      * @var bool
      */
-	protected $defer = true;
+    protected $defer = true;
 
-	/**
-	 * Register the service provider.
-	 *
-	 * @return void
-	 */
+    /**
+     * Register the service provider.
+     *
+     * @return void
+     */
     public function register()
     {
-			$this->registerSwiftMailer();
+            $this->registerSwiftMailer();
 
-        	$this->app->singleton('mailer', function ($app) {
-			// Once we have create the mailer instance, we will set a container instance
-			// on the mailer. This allows us to resolve mailer classes via containers
-			// for maximum testability on said classes instead of passing Closures.
-			$mailer = new Mailer(
-				$app['view'], $app['swift.mailer'], $app['events']
-			);
+            $this->app->singleton('mailer', function ($app) {
+            // Once we have create the mailer instance, we will set a container instance
+            // on the mailer. This allows us to resolve mailer classes via containers
+            // for maximum testability on said classes instead of passing Closures.
+            $mailer = new Mailer(
+                $app['view'], $app['swift.mailer'], $app['events']
+            );
 
-			$this->setMailerDependencies($mailer, $app);
+            $this->setMailerDependencies($mailer, $app);
 
-			// If a "from" address is set, we will set it on the mailer so that all mail
-			// messages sent by the applications will utilize the same "from" address
-			// on each one, which makes the developer's life a lot more convenient.
-			$from = $app['config']['mail.from'];
+            // If a "from" address is set, we will set it on the mailer so that all mail
+            // messages sent by the applications will utilize the same "from" address
+            // on each one, which makes the developer's life a lot more convenient.
+            $from = $app['config']['mail.from'];
 
-			if (is_array($from) && isset($from['address'])) {
-				$mailer->alwaysFrom($from['address'], $from['name']);
-			}
+            if (is_array($from) && isset($from['address'])) {
+                $mailer->alwaysFrom($from['address'], $from['name']);
+            }
 
             $to = $app['config']['mail.to'];
 
@@ -48,45 +48,45 @@ class LaravelMailProvider extends ServiceProvider
                 $mailer->alwaysTo($to['address'], $to['name']);
             }
 
-			return $mailer;
-		});
-	}
+            return $mailer;
+        });
+    }
 
-	/**
-	 * Set a few dependencies on the mailer instance.
-	 *
-	 * @param  \Illuminate\Mail\Mailer  $mailer
-	 * @param  \Illuminate\Foundation\Application  $app
-	 * @return void
-	 */
+    /**
+     * Set a few dependencies on the mailer instance.
+     *
+     * @param  \Illuminate\Mail\Mailer  $mailer
+     * @param  \Illuminate\Foundation\Application  $app
+     * @return void
+     */
     protected function setMailerDependencies($mailer, $app)
     {
-		$mailer->setContainer($app);
+        $mailer->setContainer($app);
 
-		if ($app->bound('queue')) {
+        if ($app->bound('queue')) {
             $mailer->setQueue($app['queue']);
-		}
-	}
+        }
+    }
 
-	/**
-	 * Register the Swift Mailer instance.
-	 *
-	 * @return void
-	 */
-	public function registerSwiftMailer() {
-		$this->app['swift.mailer'] = $this->app->share(function ($app) {
-			$token = $this->app['config']->get('services.postmark');
-			return new Swift_Mailer(new \Postmark\Transport($token));
-		});
-	}
+    /**
+     * Register the Swift Mailer instance.
+     *
+     * @return void
+     */
+    public function registerSwiftMailer() {
+        $this->app['swift.mailer'] = $this->app->share(function ($app) {
+            $token = $this->app['config']->get('services.postmark');
+            return new Swift_Mailer(new \Postmark\Transport($token));
+        });
+    }
 
-	/**
-	 * Get the services provided by the provider.
-	 *
-	 * @return array
-	 */
-	public function provides() {
-		return ['mailer', 'swift.mailer'];
-	}
+    /**
+     * Get the services provided by the provider.
+     *
+     * @return array
+     */
+    public function provides() {
+        return ['mailer', 'swift.mailer'];
+    }
 
 }

--- a/src/Postmark/Adapters/LaravelMailProvider.php
+++ b/src/Postmark/Adapters/LaravelMailProvider.php
@@ -5,6 +5,7 @@ use Illuminate\Support\ServiceProvider;
 use Swift_Mailer;
 
 class LaravelMailProvider extends ServiceProvider {
+
 	/**
 	 * Indicates if loading of the provider is deferred.
 	 *

--- a/src/Postmark/Adapters/LaravelMailProvider.php
+++ b/src/Postmark/Adapters/LaravelMailProvider.php
@@ -1,11 +1,17 @@
-<?php namespace Postmark\Adapters;
+<?php
+namespace Postmark\Adapters;
 
 use Illuminate\Mail\Mailer;
 use Illuminate\Support\ServiceProvider;
 use Swift_Mailer;
 
-class LaravelMailProvider extends ServiceProvider {
-
+class LaravelMailProvider extends ServiceProvider
+{
+	/**
+     * Indicates if loading of the provider is deferred.
+     *
+     * @var bool
+     */
 	protected $defer = true;
 
 	/**
@@ -13,10 +19,11 @@ class LaravelMailProvider extends ServiceProvider {
 	 *
 	 * @return void
 	 */
-	public function register() {
-		$this->app->singleton('mailer', function ($app) {
+    public function register()
+    {
 			$this->registerSwiftMailer();
 
+        	$this->app->singleton('mailer', function ($app) {
 			// Once we have create the mailer instance, we will set a container instance
 			// on the mailer. This allows us to resolve mailer classes via containers
 			// for maximum testability on said classes instead of passing Closures.
@@ -35,6 +42,12 @@ class LaravelMailProvider extends ServiceProvider {
 				$mailer->alwaysFrom($from['address'], $from['name']);
 			}
 
+            $to = $app['config']['mail.to'];
+
+            if (is_array($to) && isset($to['address'])) {
+                $mailer->alwaysTo($to['address'], $to['name']);
+            }
+
 			return $mailer;
 		});
 	}
@@ -46,11 +59,12 @@ class LaravelMailProvider extends ServiceProvider {
 	 * @param  \Illuminate\Foundation\Application  $app
 	 * @return void
 	 */
-	protected function setMailerDependencies($mailer, $app) {
+    protected function setMailerDependencies($mailer, $app)
+    {
 		$mailer->setContainer($app);
 
 		if ($app->bound('queue')) {
-			$mailer->setQueue($app['queue.connection']);
+            $mailer->setQueue($app['queue']);
 		}
 	}
 

--- a/src/Postmark/Adapters/LaravelMailProvider.php
+++ b/src/Postmark/Adapters/LaravelMailProvider.php
@@ -17,8 +17,7 @@ class LaravelMailProvider extends ServiceProvider {
 	 *
 	 * @return void
 	 */
-	public function register()
-	{
+	public function register() {
 		$this->registerSwiftMailer();
 
 		$this->app->singleton('mailer', function ($app) {
@@ -57,8 +56,7 @@ class LaravelMailProvider extends ServiceProvider {
 	 * @param  \Illuminate\Foundation\Application  $app
 	 * @return void
 	 */
-	protected function setMailerDependencies($mailer, $app)
-	{
+	protected function setMailerDependencies($mailer, $app) {
 		$mailer->setContainer($app);
 
 		if ($app->bound('queue')) {
@@ -83,7 +81,7 @@ class LaravelMailProvider extends ServiceProvider {
 	 *
 	 * @return array
 	 */
-    public function provides() {
+	public function provides() {
 		return ['mailer', 'swift.mailer'];
 	}
 


### PR DESCRIPTION
When upgrading to Laravel 5.3 I encountered a warning about the [queue](https://laravel.com/docs/5.3/queues) used so I decided to write a patch (i.e. copy [the default `MailServiceProvider`](https://github.com/laravel/framework/blob/5.3/src/Illuminate/Mail/MailServiceProvider.php)) to add compatibility with Laravel 5.3. This package now also supports [a universal "to" address](https://laravel.com/docs/5.3/mail#mail-and-local-development).

I did **not** test this PR against older Laravel versions, so I'd suggest marking this a breaking change.

Let me know if you'd like me to make any changes!
